### PR TITLE
Make polybar-mail executable by polybar

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@
 
 ```bash
 git clone http://github.com/ntk148v/polybar-mail.git
+cd polybar-mail
 cp polybarmail.py ~/.config/polybar/polybarmail.py
 cp mail.ini ~/.config/polybar/mail.ini
 # Modify mail.ini with your mail configuration

--- a/polybarmail.py
+++ b/polybarmail.py
@@ -1,3 +1,5 @@
+#!/bin/env python3
+
 import argparse
 import configparser
 import imaplib


### PR DESCRIPTION
small change to make this repo easier to drop right in to an existing i3 configuration.

## Description
Resolves issue where `polybar-mail` script would fail because `polybar` couldn't execute it directly. While here, adds `cd` step to Installation instructions, for lazy copy+pasters like me.

## Related Issue
N/A I believe.

## Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Chore (non-breaking change that does not add functionality or fix an issue)
